### PR TITLE
修复iOS下时间显示错误的bug

### DIFF
--- a/yubisaki.js
+++ b/yubisaki.js
@@ -106,7 +106,7 @@ function normalizeYaml() {
     let matterObject = YAML.load(ymlPath)
 
     const result = Object.assign({}, matterObject, {
-        date: date.Format('yyyy-MM-dd hh:mm:ss')
+        date: date.Format('yyyy-MM-dd hh:mm:ss').replace(/\-/g, '/')
     })
 
     return YAML.stringify(result, 4, 2)


### PR DESCRIPTION
用safari 或iOS 系统打开这个链接 https://lewiscutey.github.io/blog/blog/vuepress-theme-toos.html
时间全是NaN,是因为https://www.cnblogs.com/lewiscutey/p/9382575.html
这个问题导致的，这个是我测试过后的页面https://lewiscutey.github.io/blog/blog/hello.html